### PR TITLE
fix: rewards start week

### DIFF
--- a/scripts/common/config/config.ts
+++ b/scripts/common/config/config.ts
@@ -36,7 +36,7 @@ export const addresses: Addresses = {
 export const config: Config = {
   earnRewardsRatio: 0.6,
   borrowRewardsRatio: 0.4,
-  rewardStartWeek: 2792,
+  rewardStartWeek: 2793,
   multiplier: 100000000000,
   dryRun: true,
   weeksCount: 50,


### PR DESCRIPTION
change start week from `2792` to `2793`. Week `2792` had one day worth of rewards, one day before launch of Ajna.